### PR TITLE
feat: Configure GitHub Issues with templates and labels

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -53,7 +53,10 @@
       "Bash(TASK_ID=*)",
       "Bash(jq:*)",
       "Bash(kotlinc:*)",
-      "Bash(gh pr edit:*)"
+      "Bash(gh pr edit:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh label:*)",
+      "Bash(gh repo edit:*)"
     ],
     "deny": []
   }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report a bug or issue with RD Watch
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: android-version
+    attributes:
+      label: Android TV Version
+      description: What version of Android TV are you running?
+      placeholder: ex. Android TV 11, Android TV 12
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: What Android TV device are you using?
+      placeholder: ex. Nvidia Shield TV, Chromecast with Google TV, Sony TV
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Navigate using remote to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/adinunzio10/rd-watch/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/adinunzio10/rd-watch/discussions
+    about: Ask questions and discuss ideas with the community
+  - name: Documentation
+    url: https://github.com/adinunzio10/rd-watch/blob/main/README.md
+    about: Check the documentation for setup and usage instructions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Suggest an idea for RD Watch
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when...
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: checkboxes
+    id: feature-type
+    attributes:
+      label: Feature Category
+      description: What type of feature is this? (Select all that apply)
+      options:
+        - label: UI/UX improvement
+        - label: Remote control navigation
+        - label: Android TV specific functionality
+        - label: Performance improvement
+        - label: New content feature
+        - label: Authentication/Security
+        - label: Media playback
+        - label: Other
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or mockups about the feature request here.
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/adinunzio10/rd-watch/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
## Summary
- Add comprehensive GitHub Issues configuration for RD Watch Android TV app
- Create bug report template with Android TV specific fields (device, Android version)
- Add feature request template with categorization options
- Configure issue template settings to disable blank issues and provide helpful links

## New Issue Labels
- `android-tv` - Android TV specific issues
- `ui/ux` - User interface and experience issues  
- `remote-control` - Remote control navigation issues
- `compose` - Jetpack Compose related issues

## Test plan
- [x] Bug report template includes Android TV specific fields
- [x] Feature request template has appropriate categories
- [x] Issue template configuration prevents blank issues
- [x] All labels created successfully

🤖 Generated with [Claude Code](https://claude.ai/code)