### PR TITLE
Fix: Database migration crash - add missing @ColumnInfo defaults

### DIFF
--- a/app/src/main/java/com/rdwatch/androidtv/data/entities/ContentEntity.kt
+++ b/app/src/main/java/com/rdwatch/androidtv/data/entities/ContentEntity.kt
@@ -1,5 +1,6 @@
 package com.rdwatch.androidtv.data.entities
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.util.Date
@@ -28,8 +29,11 @@ data class ContentEntity(
     val tmdbId: Int? = null,
     val addedDate: Date = Date(),
     val lastPlayedDate: Date? = null,
+    @ColumnInfo(defaultValue = "0")
     val playCount: Int = 0,
+    @ColumnInfo(defaultValue = "0")
     val isFavorite: Boolean = false,
+    @ColumnInfo(defaultValue = "0")
     val isWatched: Boolean = false
 )
 


### PR DESCRIPTION
## Summary
- Fixed app crash on launch caused by Room database schema validation error
- Added missing `@ColumnInfo(defaultValue = "0")` annotations to ContentEntity

## Problem
The app was crashing with `IllegalStateException: Migration didn't properly handle` because:
- MIGRATION_2_3 defined SQL columns with `DEFAULT 0` values
- ContentEntity didn't have corresponding `@ColumnInfo` annotations
- Room expected columns without defaults but found columns with defaults

## Solution
Added `@ColumnInfo(defaultValue = "0")` to three fields in ContentEntity:
- `playCount: Int` 
- `isFavorite: Boolean`
- `isWatched: Boolean`

## Test Plan
- [x] Build completes successfully
- [ ] App launches without crashing
- [ ] Database migration runs correctly
- [ ] Content data persists properly

🤖 Generated with [Claude Code](https://claude.ai/code)