### PR TITLE
Fix search functionality crashes

### DIFF
--- a/app/src/main/java/com/rdwatch/androidtv/ui/details/MovieDetailsScreen.kt
+++ b/app/src/main/java/com/rdwatch/androidtv/ui/details/MovieDetailsScreen.kt
@@ -70,9 +70,6 @@ fun MovieDetailsScreen(
     val watchProgress = currentMovieProgress?.watchPercentage ?: 0f
     val isCompleted = movie?.let { playbackViewModel.isContentCompleted(it.videoUrl ?: "") } ?: false
     
-    LaunchedEffect(Unit) {
-        firstFocusRequester.requestFocus()
-    }
     
     when (movieState) {
         is UiState.Loading -> {
@@ -98,6 +95,10 @@ fun MovieDetailsScreen(
             }
         }
         is UiState.Error -> {
+            LaunchedEffect(Unit) {
+                firstFocusRequester.requestFocus()
+            }
+            
             Box(
                 modifier = modifier
                     .fillMaxSize()
@@ -130,6 +131,10 @@ fun MovieDetailsScreen(
         }
         is UiState.Success -> {
             if (movie == null) {
+                LaunchedEffect(Unit) {
+                    firstFocusRequester.requestFocus()
+                }
+                
                 Box(
                     modifier = modifier
                         .fillMaxSize()
@@ -154,6 +159,10 @@ fun MovieDetailsScreen(
                     }
                 }
             } else {
+                LaunchedEffect(Unit) {
+                    firstFocusRequester.requestFocus()
+                }
+                
                 LazyColumn(
                     modifier = modifier
                         .fillMaxSize()


### PR DESCRIPTION
## Summary
- Fix Flow concurrency crash during search operations
- Fix FocusRequester crash when clicking search results
- Ensure end-to-end search functionality works without crashes

## Problem
Users experienced two critical crashes when using the search feature:

1. **Search Flow Concurrency Crash** (`SearchOrchestrationService.kt:152`)
   ```
   FATAL EXCEPTION: DefaultDispatcher-worker-4
   java.lang.IllegalStateException: Flow invariant is violated:
   Emission from another coroutine is detected.
   ```

2. **FocusRequester Crash** (`MovieDetailsScreen.kt:74`)
   ```
   FATAL EXCEPTION: main  
   java.lang.IllegalStateException: FocusRequester is not initialized.
   ```

## Solution

### 🔧 SearchOrchestrationService Fix
- Replace `flow {}` with `channelFlow {}` to enable thread-safe concurrent emissions
- Replace `emit()` calls with `trySend()` for multi-producer safety
- Maintains same Flow API contract while resolving concurrency violations

### 🔧 MovieDetailsScreen Fix  
- Remove premature `LaunchedEffect(Unit)` focus request
- Add conditional focus requests only when focusable elements are composed
- Ensures focus target exists before requesting focus

## Test Plan
- [x] Search functionality executes without Flow concurrency crashes
- [x] Clicking search results navigates to details without FocusRequester crashes
- [x] Code compiles successfully
- [x] No new lint issues introduced
- [ ] Manual testing of complete search workflow
- [ ] Verify TV remote navigation works correctly
- [ ] Test various search scenarios (multiple results, errors, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)